### PR TITLE
Add docker-compose stack, schema, and sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# purchase-planner-poc
-purchase-planner-poc
+# Seasonal Purchase Planner POC
+
+This repository contains a quickstart proof-of-concept for exploring ERP data with PostgreSQL, Adminer, and Metabase. It sets up a local analytics stack and provides SQL to create staging tables and simple BI views.
+
+## Getting Started
+
+1. **Start the stack**
+   ```bash
+   docker compose up -d
+   ```
+   Services will be available at:
+   - **Postgres**
+     - Host: `postgres` (inside Docker network) or `localhost:5432` from your machine
+     - `POSTGRES_USER=planner`
+     - `POSTGRES_PASSWORD=planner`
+     - `POSTGRES_DB=erp`
+   - **Adminer**
+     - URL: [http://localhost:8080](http://localhost:8080)
+     - Connect to Postgres using host `postgres` from the Adminer container or `localhost` from the host
+   - **Metabase**
+     - URL: [http://localhost:3000](http://localhost:3000)
+     - When adding the database, set host to `postgres` so Metabase reaches Postgres via the Docker network
+
+2. **Create schemas and tables**
+
+   In Adminer choose the `erp` database, click **SQL command**, then either paste the contents of [`sql/schema.sql`](sql/schema.sql) or use the *File to upload* field to upload it and execute so all tables and views are created. The file can also be run via `psql -f sql/schema.sql` if you prefer the CLI.
+
+3. **Import CSV data**
+
+    Save your files with **UTF-8 encoding** and **comma** separators. If any values need quoting, wrap them in **double quotes** to match Adminer defaults. Import the CSVs into the `stage_*` tables via Adminer (Table → Import → CSV) and see [Section 7](#7-troubleshooting) if Adminer misreads delimiters or quotes. Sample files in [`sample_data/`](sample_data/) demonstrate the required headers and one row of data for each table:
+
+    `dim_product.csv` → `stage_dim_product`
+
+    ```csv
+    sku,fruit,variety,size,label,grade,origin
+    APPL001,Apple,Gala,Medium,FarmCo,A,USA
+    ```
+
+    `sales_2024.csv` → `stage_fact_sales`
+
+    ```csv
+    txn_date,sku,qty_kg,revenue,channel
+    2024-01-15,APPL001,100,2000,Wholesale
+    ```
+
+    `purchase_2024.csv` → `stage_fact_purchase`
+
+    ```csv
+    po_date,grn_date,sku,supplier,qty_kg,unit_cost
+    2023-12-20,2024-01-05,APPL001,SupplierCo,120,10.50
+    ```
+
+    `inventory_2024.csv` → `stage_fact_inventory`
+
+    ```csv
+    snap_date,sku,on_hand_kg,in_transit_kg
+    2024-01-31,APPL001,80,20
+    ```
+
+    Use these as templates when preparing your own data and import them via Adminer. Ensure the headers match the columns defined in [`sql/schema.sql`](sql/schema.sql); for example, the purchase file must include `po_date`, `grn_date`, `sku`, `supplier`, `qty_kg`, and `unit_cost` to align with `stage_fact_purchase`.
+
+4. **Explore in Metabase**
+
+   Connect Metabase to the `erp` database (host `postgres`, user `planner`, password `planner`) and build dashboards using the provided views.
+
+
+## 7) Troubleshooting
+
+- Postgres not up: `docker logs poc_postgres` (check for port 5432 conflicts).
+- Metabase first launch is slow: wait 1–2 minutes for initialization.
+- Import CSV fails due to delimiters or quotes: switch to a `;` delimiter or set `QUOTE '"'` in Adminer.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+autoupdate: true
+services:
+  postgres:
+    image: postgres:15
+    container_name: poc_postgres
+    environment:
+      POSTGRES_USER: planner
+      POSTGRES_PASSWORD: planner
+      POSTGRES_DB: erp
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  adminer:
+    image: adminer:latest
+    container_name: poc_adminer
+    depends_on:
+      - postgres
+    ports:
+      - "8080:8080"
+
+  metabase:
+    image: metabase/metabase:latest
+    container_name: poc_metabase
+    ports:
+      - "3000:3000"
+    environment:
+      MB_PLUGIN_DIR: /plugins
+    volumes:
+      - mbdata:/metabase-data
+
+volumes:
+  pgdata:
+  mbdata:

--- a/sample_data/dim_product.csv
+++ b/sample_data/dim_product.csv
@@ -1,0 +1,2 @@
+sku,fruit,variety,size,label,grade,origin
+APPL001,Apple,Gala,Medium,FarmCo,A,USA

--- a/sample_data/inventory_2024.csv
+++ b/sample_data/inventory_2024.csv
@@ -1,0 +1,2 @@
+snap_date,sku,on_hand_kg,in_transit_kg
+2024-01-31,APPL001,80,20

--- a/sample_data/purchase_2024.csv
+++ b/sample_data/purchase_2024.csv
@@ -1,0 +1,2 @@
+po_date,grn_date,sku,supplier,qty_kg,unit_cost
+2023-12-20,2024-01-05,APPL001,SupplierCo,120,10.50

--- a/sample_data/sales_2024.csv
+++ b/sample_data/sales_2024.csv
@@ -1,0 +1,2 @@
+txn_date,sku,qty_kg,revenue,channel
+2024-01-15,APPL001,100,2000,Wholesale

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,58 @@
+CREATE SCHEMA IF NOT EXISTS stage;
+CREATE SCHEMA IF NOT EXISTS marts;
+
+-- Master/Product
+CREATE TABLE IF NOT EXISTS stage_dim_product (
+  sku TEXT PRIMARY KEY,
+  fruit TEXT,
+  variety TEXT,
+  size TEXT,
+  label TEXT,
+  grade TEXT,
+  origin TEXT
+);
+
+-- Sales fact (ngày)
+CREATE TABLE IF NOT EXISTS stage_fact_sales (
+  txn_date DATE,
+  sku TEXT REFERENCES stage_dim_product(sku),
+  qty_kg NUMERIC,
+  revenue NUMERIC,
+  channel TEXT
+);
+
+-- Purchase fact (PO/GRN)
+CREATE TABLE IF NOT EXISTS stage_fact_purchase (
+  po_date DATE,
+  grn_date DATE,
+  sku TEXT REFERENCES stage_dim_product(sku),
+  supplier TEXT,
+  qty_kg NUMERIC,
+  unit_cost NUMERIC
+);
+
+-- Inventory snapshot (cuối ngày/tháng)
+CREATE TABLE IF NOT EXISTS stage_fact_inventory (
+  snap_date DATE,
+  sku TEXT REFERENCES stage_dim_product(sku),
+  on_hand_kg NUMERIC,
+  in_transit_kg NUMERIC
+);
+
+-- Bán theo tháng
+CREATE OR REPLACE VIEW marts_v_monthly_sales AS
+SELECT date_trunc('month', txn_date)::date AS month,
+       sku,
+       SUM(qty_kg) AS qty_kg,
+       SUM(revenue) AS revenue
+FROM stage_fact_sales
+GROUP BY 1,2;
+
+-- Tồn cuối tháng
+CREATE OR REPLACE VIEW marts_v_monthly_inventory AS
+SELECT date_trunc('month', snap_date)::date AS month,
+       sku,
+       SUM(on_hand_kg) AS on_hand_kg,
+       SUM(in_transit_kg) AS in_transit_kg
+FROM stage_fact_inventory
+GROUP BY 1,2;


### PR DESCRIPTION
## Summary
- Add Docker Compose for Postgres, Adminer, and Metabase
- Provide SQL schema and views for staging tables and monthly aggregations
- Document service hostnames and credentials for Postgres, Adminer, and Metabase connections
- Expand CSV import instructions with example filenames, encoding, delimiter, and quoting requirements and link to troubleshooting
- Include purchase CSV example and required columns for `stage_fact_purchase`
- Supply sample CSV datasets in `sample_data/` for products, sales, purchases, and inventory
- Show snippets of each sample CSV in README so users can see headers and sample rows before importing
- Clarify how to execute `sql/schema.sql` in Adminer via SQL command or file upload

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a86c01688324be99019524bcfaaf